### PR TITLE
Fixes missing curly brace and parenthese.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ geocoder
   .geocode('1109 N Highland St, Arlington, VA')
   .then(response => {
     console.log(response);
-
+  })
     /*
     response => {
       "input": {


### PR DESCRIPTION
The then() function in the Geocodio example is missing the closing "}" and ")". This request fixes the missing code.