### PR TITLE
'Unsupported engine' error: package expects non-existent version of NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^1.19.1"
   },
   "engines": {
-    "npm": ">= 8.0.0"
+    "node": ">= 8.0.0"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
[This line](https://github.com/Geocodio/geocodio-library-node/blob/477aa3956be94ad55a747df2f7539fc81e5f9c4a/package.json#L35) indicates that this package requires NPM 8.0.0 or greater, which [does not exist](https://www.npmjs.com/package/npm). As a result, NPM is generating the following warning upon package install:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'geocodio-library-node@1.3.1',
npm WARN EBADENGINE   required: { npm: '>= 8.0.0' },
npm WARN EBADENGINE   current: { node: 'v14.16.0', npm: '7.6.1' }
npm WARN EBADENGINE }
```

I'm assuming that it's meant to refer to the Node version - change made accordingly below.