### PR TITLE
Fix Axios require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const axios = require("axios/dist/node/axios.cjs");
+const axios = require("axios");
 const fs = require("fs");
 const FormData = require("form-data");
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
   },
   "repository": "Geocodio/geocodio-library-node",
   "jest": {
+    "moduleNameMapper": {
+      "axios": "<rootDir>/node_modules/axios/dist/node/axios.cjs"
+    },
     "testEnvironment": "node"
   },
   "license": "MIT",


### PR DESCRIPTION
ac49992a9 changed the way Axios is `require`'d, to satisfy Jest, but this breaks the library for other consumers. The referenced file isn't exported by Axios' package.json, so you get this error:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/node/axios.cjs' is not defined by "exports" in [...]/node_modules/axios/package.json
```

You can repro that here by running `node` and executing:

```js
const geocodio = require('./lib/index.js')
```

This solves the problem by fixing the require of Axios, and adding a module name mapper to the Jest config to get it to use the correct file. (This seems to me like a bug in Jest, but this is an OK workaround.)

Tested with the above line in `node`, and `npm test`.