### PR TITLE
Narrow geocode param types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,6 +17,8 @@ declare module 'geocodio-library-node' {
     postal_code?: string; // Alternative to zip used in some API calls
   }
 
+  export type AddressInputComponents = Pick<AddressComponents, "street" | "city" | "county" | "state" | "postal_code" | "country">
+
   export type GeocodeAccuracyType =
     | 'rooftop'
     | 'point'
@@ -259,8 +261,8 @@ declare module 'geocodio-library-node' {
   export default class Geocodio {
     constructor(apiKey?: string, hostname?: string, apiVersion?: string);
 
-    geocode(query: string | AddressComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
-    geocode(query: (string | AddressComponents)[] | Record<string, string | AddressComponents>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse>;
+    geocode(query: string | AddressInputComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
+    geocode(query: (string | AddressInputComponents)[] | Record<string, string | AddressInputComponents>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse>;
 
     reverse(query: string | [number, number], fields?: FieldOption[], limit?: number): Promise<ReverseGeocodeResponse>;
     reverse(query: (string | [number, number])[] | Record<string, string | [number, number]>, fields?: FieldOption[], limit?: number): Promise<BatchReverseGeocodeResponse>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.7.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geocodio-library-node",
-      "version": "1.7.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",


### PR DESCRIPTION
Currently, if you pass all the fields allowed by the type system to `geocoder.geocode()`, the API will return warnings that it was not expecting.

Without changing any functionality, this change to the declaration file improves developer experience for TypeScript users by having the typing system more closely match the alternate URL parameters laid out [in the docs](https://www.geocod.io/docs/#single-address).

Also updates library version to 1.10.0 in `package-lock.json`.