### PR TITLE
Dynamic return types using generics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -228,9 +228,9 @@ declare module 'geocodio-library-node' {
     results: GeocodedAddress[];
   }
 
-  export interface BatchGeocodeResponse {
+  export interface BatchGeocodeResponse<Q extends string | AddressInputComponents> {
     results: Array<{
-      query: string;
+      query: Q;
       response: SingleGeocodeResponse;
     }> | Record<string, {
       response: SingleGeocodeResponse;
@@ -262,7 +262,7 @@ declare module 'geocodio-library-node' {
     constructor(apiKey?: string, hostname?: string, apiVersion?: string);
 
     geocode(query: string | AddressInputComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
-    geocode(query: (string | AddressInputComponents)[] | Record<string, string | AddressInputComponents>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse>;
+    geocode<Q extends string | AddressInputComponents>(query: Q[] | Record<string, Q>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse<Q>>;
 
     reverse(query: string | [number, number], fields?: FieldOption[], limit?: number): Promise<ReverseGeocodeResponse>;
     reverse(query: (string | [number, number])[] | Record<string, string | [number, number]>, fields?: FieldOption[], limit?: number): Promise<BatchReverseGeocodeResponse>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -228,11 +228,11 @@ declare module 'geocodio-library-node' {
     results: GeocodedAddress[];
   }
 
-  export interface BatchGeocodeResponse<Q extends string | AddressInputComponents> {
-    results: Array<{
+  export interface BatchGeocodeResponse<Q extends string | AddressInputComponents, T extends Array<Q> | Record<string, Q>> {
+    results: T extends Array<Q> ? Array<{
       query: Q;
       response: SingleGeocodeResponse;
-    }> | Record<string, {
+    }> : Record<string, {
       response: SingleGeocodeResponse;
     }>;
   }
@@ -241,11 +241,11 @@ declare module 'geocodio-library-node' {
     results: GeocodedAddress[];
   }
 
-  export interface BatchReverseGeocodeResponse {
-    results: Array<{
-      query: string;
+  export interface BatchReverseGeocodeResponse<Q extends string | [number, number], T extends Array<Q> | Record<string, Q>> {
+    results: T extends Array<Q> ? Array<{
+      query: Q;
       response: ReverseGeocodeResponse;
-    }> | Record<string, {
+    }> : Record<string, {
       response: ReverseGeocodeResponse;
     }>;
   }
@@ -262,10 +262,10 @@ declare module 'geocodio-library-node' {
     constructor(apiKey?: string, hostname?: string, apiVersion?: string);
 
     geocode(query: string | AddressInputComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
-    geocode<Q extends string | AddressInputComponents>(query: Q[] | Record<string, Q>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse<Q>>;
+    geocode<Q extends string | AddressInputComponents, T extends Array<Q> | Record<string, Q>>(query: T, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse<Q, T>>;
 
     reverse(query: string | [number, number], fields?: FieldOption[], limit?: number): Promise<ReverseGeocodeResponse>;
-    reverse(query: (string | [number, number])[] | Record<string, string | [number, number]>, fields?: FieldOption[], limit?: number): Promise<BatchReverseGeocodeResponse>;
+    reverse<Q extends string | [number, number], T extends Array<Q> | Record<string, Q>>(query: T, fields?: FieldOption[], limit?: number): Promise<BatchReverseGeocodeResponse<Q, T>>;
 
     list: {
       create(filename: string, direction: string, format: string, callback: string): Promise<ListResponse>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -233,7 +233,7 @@ declare module 'geocodio-library-node' {
     results: T extends Array<Q> ? Array<{
       query: Q;
       response: SingleGeocodeResponse;
-    }> : Record<string, {
+    }> : Record<keyof T, {
       response: SingleGeocodeResponse;
     }>;
   }
@@ -247,7 +247,7 @@ declare module 'geocodio-library-node' {
     results: T extends Array<Q> ? Array<{
       query: Q;
       response: ReverseGeocodeResponse;
-    }> : Record<string, {
+    }> : Record<keyof T, {
       response: ReverseGeocodeResponse;
     }>;
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,6 +17,8 @@ declare module 'geocodio-library-node' {
     postal_code?: string; // Alternative to zip used in some API calls
   }
 
+  export type AddressInputComponents = Pick<AddressComponents, "street" | "city" | "county" | "state" | "postal_code" | "country">
+
   export type GeocodeAccuracyType =
     | 'rooftop'
     | 'point'
@@ -259,8 +261,8 @@ declare module 'geocodio-library-node' {
   export default class Geocodio {
     constructor(apiKey?: string, hostname?: string, apiVersion?: string);
 
-    geocode(query: string | AddressComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
-    geocode(query: (string | AddressComponents)[] | Record<string, string | AddressComponents>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse>;
+    geocode(query: string | AddressInputComponents, fields?: FieldOption[], limit?: number): Promise<SingleGeocodeResponse>;
+    geocode(query: (string | AddressInputComponents)[] | Record<string, string | AddressInputComponents>, fields?: FieldOption[], limit?: number): Promise<BatchGeocodeResponse>;
 
     reverse(query: string | [number, number], fields?: FieldOption[], limit?: number): Promise<ReverseGeocodeResponse>;
     reverse(query: (string | [number, number])[] | Record<string, string | [number, number]>, fields?: FieldOption[], limit?: number): Promise<BatchReverseGeocodeResponse>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -226,6 +226,7 @@ declare module 'geocodio-library-node' {
       formatted_address: string;
     };
     results: GeocodedAddress[];
+    _warnings?: string[];
   }
 
   export interface BatchGeocodeResponse<Q extends string | AddressInputComponents, T extends Array<Q> | Record<string, Q>> {
@@ -239,6 +240,7 @@ declare module 'geocodio-library-node' {
 
   export interface ReverseGeocodeResponse {
     results: GeocodedAddress[];
+    _warnings?: string[];
   }
 
   export interface BatchReverseGeocodeResponse<Q extends string | [number, number], T extends Array<Q> | Record<string, Q>> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.7.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geocodio-library-node",
-      "version": "1.7.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",


### PR DESCRIPTION
Only changes type declaration file. Code functionality unchanged. All changes tested while using the library in a project.
Changes can be viewed commit-by-commit to see how the final types were built up to. This is on top of #44.

1. Geocoding queries can be strings or address component objects
2. Infer return type is array if input is array, or record if input is record
3. If we know the keys of a record, recognize key types as those keys specifically
4. optional `_warnings` property on response objects