### PR TITLE
include query in Record batch responses too

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -234,6 +234,7 @@ declare module 'geocodio-library-node' {
       query: Q;
       response: SingleGeocodeResponse;
     }> : Record<keyof T, {
+      query: Q;
       response: SingleGeocodeResponse;
     }>;
   }
@@ -248,6 +249,7 @@ declare module 'geocodio-library-node' {
       query: Q;
       response: ReverseGeocodeResponse;
     }> : Record<keyof T, {
+      query: Q;
       response: ReverseGeocodeResponse;
     }>;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geocodio-library-node",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",


### PR DESCRIPTION
Original input is also included in batch results when batch processing JSON objects, not just JSON arrays.