### PR TITLE
Security: patch tmp path traversal (CVE-2026-44705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `geocodio-library-node` will be documented in this file
 
+## 1.15.1 - 2026-05-28
+
+- **Security:** Patched transitive `tmp` dependency to `^0.2.4` to address path traversal vulnerability (CVE-2026-44705). Dev-only dependency; no runtime impact.
+
 ## 1.15.0 - 2026-03-12
 
 - Updated default API version to v1.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.14.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geocodio-library-node",
-      "version": "1.14.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",
@@ -6673,15 +6673,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -7630,15 +7621,13 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "geocod.io geocoding API library",
   "homepage": "https://github.com/Geocodio/geocodio-library-node",
   "author": {
@@ -84,5 +84,8 @@
   "dependencies": {
     "axios": "^1.7.4",
     "form-data": "^4.0.0"
+  },
+  "overrides": {
+    "tmp": "^0.2.4"
   }
 }


### PR DESCRIPTION
## Summary

- Adds npm `overrides` forcing `tmp` to `^0.2.4` (resolves to `0.2.7`) to patch CVE-2026-44705 path traversal
- `tmp` is a transitive **dev-only** dependency via `eslint → inquirer → external-editor` — no runtime impact for consumers (only `lib/` is published)
- Bumps to **1.15.1** + CHANGELOG entry (rebased on top of latest master, was 1.11.1 before rebase)

Closes ENG-931

## Test plan

- [x] `npm ls tmp` shows `tmp@0.2.7 overridden`
- [x] `npm audit` no longer flags `tmp`
- [x] ESLint passes
- [x] All 54 tests pass locally with API key
- [ ] CI green across Node 18/20/22/23
- [ ] After merge: `npm publish` + tag `v1.15.1` (handled by maintainer)