### PR TITLE
Migrate to Geocodio API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `geocodio-library-node` will be documented in this file
 
+## 2.0.0 - 2026-06-05
+
+- **Breaking:** Migrated to Geocodio API v2 (base URL version prefix is now `v2`).
+- **Breaking:** The top-level `input` object has been removed from `/geocode` and `/reverse` responses. The parsed input address is now available in `results[].address_components`.
+- **Breaking:** Renamed address component keys in `address_components` and `address_components_secondary`: `zip` → `postal_code`, `state` → `state_province`, `secondaryunit` → `unit_type`, `secondarynumber` → `unit_number`.
+- Added `state_province` as an accepted address input component (the old `state` field continues to work for backwards compatibility).
+
 ## 1.11.0 - 2025-05-21
 
 - Enhanced TypeScript type definitions

--- a/README.md
+++ b/README.md
@@ -54,19 +54,6 @@ geocoder
   })
     /*
     response => {
-      "input": {
-        "address_components": {
-          "number": "1109",
-          "predirectional": "N",
-          "street": "Highland",
-          "suffix": "St",
-          "formatted_street": "N Highland St",
-          "city": "Arlington",
-          "state": "VA",
-          "country": "US"
-        },
-        "formatted_address": "1109 N Highland St, Arlington, VA"
-      },
       "results": [
         {
           "address_components": {
@@ -77,8 +64,8 @@ geocoder
             "formatted_street": "N Highland St",
             "city": "Arlington",
             "county": "Arlington County",
-            "state": "VA",
-            "zip": "22201",
+            "state_province": "VA",
+            "postal_code": "22201",
             "country": "US"
           },
           "formatted_address": "1109 N Highland St, Arlington, VA 22201",
@@ -99,8 +86,8 @@ geocoder
             "formatted_street": "N Highland St",
             "city": "Arlington",
             "county": "Arlington County",
-            "state": "VA",
-            "zip": "22201",
+            "state_province": "VA",
+            "postal_code": "22201",
             "country": "US"
           },
           "formatted_address": "1109 N Highland St, Arlington, VA 22201",
@@ -196,7 +183,7 @@ For forward geocoding requests it is possible to supply [individual address comp
 geocoder.geocode({
       street: '1109 N Highland St',
       city: 'Arlington',
-      state: 'VA',
+      state_province: 'VA',
       postal_code: '22201'
   })
   .then(response => { ... })
@@ -206,12 +193,12 @@ geocoder.geocode([
       {
           street: '1109 N Highland St',
           city: 'Arlington',
-          state: 'VA'
+          state_province: 'VA'
       },
       {
           street: '525 University Ave',
           city: 'Toronto',
-          state: 'ON',
+          state_province: 'ON',
           country: 'Canada',
       },
   ])

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -178,18 +178,23 @@ declare module 'geocodio-library-node' {
     street?: string;
     suffix?: string;
     postdirectional?: string;
-    secondaryunit?: string;
-    secondarynumber?: string;
+    unit_type?: string;
+    unit_number?: string;
     formatted_street?: string;
     city?: string;
     county?: string;
-    state?: string;
-    zip?: string;
+    state_province?: string;
+    postal_code?: string;
     country?: string;
-    postal_code?: string; // Alternative to zip used in some API calls
   }
 
-  export type AddressInputComponents = Pick<AddressComponents, "street" | "city" | "county" | "state" | "postal_code" | "country">
+  // Address input components accepted by the geocode endpoint.
+  // `state` is still accepted by the API for backwards compatibility,
+  // but `state_province` is the v2 field name.
+  export type AddressInputComponents =
+    Pick<AddressComponents, "street" | "city" | "county" | "state_province" | "postal_code" | "country"> & {
+      state?: string;
+    }
 
   export type GeocodeAccuracyType =
     | 'rooftop'
@@ -393,10 +398,6 @@ declare module 'geocodio-library-node' {
     | 'acs-social';
 
   export interface SingleGeocodeResponse {
-    input: {
-      address_components: AddressComponents;
-      formatted_address: string;
-    };
     results: GeocodedAddress[];
     _warnings?: string[];
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,13 +129,13 @@ class Geocodio {
     this.apiKey = apiKey || process.env.GEOCODIO_API_KEY || null;
     this.hostname =
       hostname || process.env.GEOCODIO_HOSTNAME || "api.geocod.io";
-    this.apiVersion = apiVersion || process.env.GEOCODIO_API_VERSION || "v1.9";
+    this.apiVersion = apiVersion || process.env.GEOCODIO_API_VERSION || "v2";
 
     this.SINGLE_TIMEOUT_MS = 5000;
     this.BATCH_TIMEOUT_MS = 30 * 60 * 1000;
 
     this.HTTP_HEADERS = {
-      "User-Agent": "geocodio-library-node/1.12.0",
+      "User-Agent": "geocodio-library-node/2.0.0",
       Authorization: `Bearer ${this.apiKey}`
     };
 
@@ -143,6 +143,7 @@ class Geocodio {
       "street",
       "city",
       "state",
+      "state_province",
       "postal_code",
       "country"
     ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geocodio-library-node",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "description": "geocod.io geocoding API library",
   "homepage": "https://github.com/Geocodio/geocodio-library-node",
   "author": {


### PR DESCRIPTION
## Summary

Migrates the Node.js library to **Geocodio API v2**. This is a **breaking change** targeting release **2.0.0** — do not tag/publish until v2 is live.

## Breaking changes

- **Base URL version prefix** changed from `v1.9` → `v2` (`https://api.geocod.io/v2/...`). Overridable via `GEOCODIO_API_VERSION`.
- **Top-level `input` removed** from `/geocode` and `/reverse` responses. Parsed input is now in `results[].address_components`. The `SingleGeocodeResponse` TS type no longer has `input`.
- **Address component keys renamed** (in `address_components` and `address_components_secondary`):
  - `zip` → `postal_code`
  - `state` → `state_province`
  - `secondaryunit` → `unit_type`
  - `secondarynumber` → `unit_number`
- **Input params:** added `state_province` to the accepted address-input components and to `AddressInputComponents`. The old `state` field is kept for backwards compatibility.

## Other changes

- `package.json` version bumped `1.13.0` → `2.0.0`.
- `User-Agent` bumped to `geocodio-library-node/2.0.0`.
- README sample responses and address-component examples updated to the v2 shape.
- CHANGELOG entry added for `2.0.0` (2026-06-05).

## Tests

`npm test` (eslint + jest). ESLint is clean. The geocode/reverse/batch/fields/lists suites and error-handling suite pass against the live v2 API. The Distance API tests fail only because the test account is out of API credits ("Please purchase more credits first…"), not due to code changes.

Note: do NOT tag or `npm publish` from this PR.